### PR TITLE
Mode d'attribution des tags + moms des rôles + stats égales

### DIFF
--- a/src/ajax.php
+++ b/src/ajax.php
@@ -17,7 +17,7 @@ if ($_GET['role'] == 'heartbeat') {
     print isset($_SESSION['current_poll']) ? json_encode($_SESSION['current_poll']) : '[]';
   }
   else {
-    print json_encode(!isset($_SESSION['current_timestamp']) || $_SESSION['current_timestamp'] < $game_timestamp);
+    print json_encode($_SESSION['current_timestamp'] == 0 || !isset($_SESSION['current_timestamp']) || $_SESSION['current_timestamp'] < $game_timestamp);
   }
 }
 elseif ($_GET['role'] == 'mj' && $_SESSION['id'] == 1) {
@@ -77,10 +77,10 @@ elseif ($_GET['role'] == 'mj' && $_SESSION['id'] == 1) {
     print "Vote limité au groupe : " . implode(', ', $choixtag_data);
   }
   if ($leadvalue == 2) {
-    print "<div class='poll-action leader-action'>👑 Le leader $leader a utilisé son pouvoir et choisi : " . $options['c' . $leadvote] . "!</div>";
+    print "<div class='poll-action leader-action'>" . $settings['role_leader'] . " $leader a utilisé son pouvoir et choisi : " . $options['c' . $leadvote] . "!</div>";
   }
   if ($traitrevalue == 2) {
-    print "<div class='poll-action traitor-action'>🗡️ Le traitre $traitre a utilisé son pouvoir et annule un choix.</div>";
+    print "<div class='poll-action traitor-action'>" . $settings['role_traitre'] . " $traitre a utilisé son pouvoir et annule un choix.</div>";
   }
 
   foreach ($votes as $key => $vote) {
@@ -163,10 +163,10 @@ if ($hp > 0) { ?>
       <div>💛 Points de vie : <b><?php print $hp; ?></b></div>
     </div>
     <?php if ($leader > 0) { ?>
-      <div class="pj-role">Vous êtes actuellement <b>Leader</b> 👑 !</div>
+      <div class="pj-role">Vous êtes actuellement <b><?php print $settings['role_leader']; ?></b> !</div>
     <?php } ?>
     <?php if ($traitre > 0) { ?>
-      <div class="pj-role">Vous êtes actuellement <b>Traitre</b> 🗡️!</div>
+      <div class="pj-role">Vous êtes actuellement <b><?php print $settings['role_traitre']; ?></b> !</div>
     <?php } ?>
   </div>
   <?php
@@ -195,10 +195,10 @@ if ($hp > 0) { ?>
         if ($leader == 1 || $traitre == 1) {
           print '<div class="powers">';
           if ($leader == 1) {
-            print "<div><input type=checkbox name=lead value=1><label for=lead>👑 Utiliser mon pouvoir de leader</label></div>";
+            print "<div><input type=checkbox name=lead value=1><label for=lead>👑 Utiliser mon pouvoir de " . $settings['role_leader'] . "</b></label></div>";
           }
           if ($traitre == 1) {
-            print "<div><input type=checkbox name=traitre value=1><label for=traitre>🗡️ Utiliser mon pouvoir de traitre et annuler le vote choisi<label></div>";
+            print "<div><input type=checkbox name=traitre value=1><label for=traitre>🗡️ Utiliser mon pouvoir de " . $settings['role_traitre'] . " et annuler le vote choisi<label></div>";
           }
           print '</div>';
         }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -378,6 +378,9 @@ tag {
 #group-stats > span {
   margin-bottom: 10px;
 }
+#group-stats > span:first-letter {
+  text-transform: uppercase;
+}
 #group > div.looser {
   background: var(--fail-background);
   color: var(--fail-color);
@@ -560,6 +563,9 @@ tag {
 }
 #poll .poll-action {
   margin-bottom: 5px;
+}
+#poll .poll-action:first-letter {
+  text-transform: capitalize;
 }
 #poll input.poll-label {
   padding: 6px 10px !important;

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -51,9 +51,9 @@ $settings = $_SESSION['settings'];
     <?php print $settings['adventure_guide']; ?>
   </div>
   <div id="group-stats">
-    <span>👑 Leader du groupe : <b class="pj-name"><?php print "$leader"; ?></b></span>
-    <span>🗡️ Traître du groupe : <b class="pj-name"><?php print "$traitre"; ?></b></span>
-    <span>💛 Joueurs encore en vie : <b><?php print $nb_alive . ' / ' . count($players); ?></b></span>
+    <span><?php print $settings['role_leader']; ?> : <b class="pj-name"><?php print "$leader"; ?></b></span>
+    <span><?php print $settings['role_traitre']; ?> : <b class="pj-name"><?php print "$traitre"; ?></b></span>
+    <span>💛 Personnages encore en vie : <b><?php print $nb_alive . ' / ' . count($players); ?></b></span>
   </div>
 </div>
 <div class="wrapper-main">
@@ -73,8 +73,8 @@ $settings = $_SESSION['settings'];
     <div id="elections" class="active">
       <h3>Nommer des personnages clefs.</h3>
       <form method="post" action="ecran.php?action=election">
-        <button name="name" value="leader" type="submit">👑 Nommer un nouveau leader</button>
-        <button name="name" value="traitre" type="submit">🗡️ Nommer un nouveau traitre</button>
+        <button name="name" value="leader" type="submit">Nommer <?php print $settings['role_leader']; ?></button>
+        <button name="name" value="traitre" type="submit">Nommer <?php print $settings['role_traitre']; ?></button>
       </form>
     </div>
     <!-- FORMULAIRE DESIGNATION -->
@@ -291,6 +291,10 @@ $settings = $_SESSION['settings'];
           <input type="text" name="adventure_name" id="adventure_name" maxlength="250" value="<?php print $settings['adventure_name']; ?>">
           <label for="adventure_guide">Adresse ip ou url pour rejoindre</label>
           <textarea type="textarea" name="adventure_guide" size=5 id="adventure_guide" maxlength="250"><?php print $settings['adventure_guide']; ?></textarea>
+          <label for="same_stats_all">Mêmes stats pour tout le monde</label>
+          <input type="checkbox" name="same_stats_all" id="same_stats_all" <?php print ($settings['same_stats_all'] ? 'checked' : ''); ?>>
+          <label for="random_tags">Tags distribués aléatoirement</label>
+          <input type="checkbox" name="random_tags" id="random_tags" <?php print ($settings['random_tags'] ? 'checked' : ''); ?>>
         </fieldset>
         <fieldset>
           <legend>1ère caractéristique</legend>
@@ -305,6 +309,13 @@ $settings = $_SESSION['settings'];
           <input type="text" placeholder="corps" name="carac2_name" id="carac2_name" value="<?php print $settings['carac2_name']; ?>">
           <label for="carac2_group">Un personnage fort dans cette carac est :</label>
           <input type="text" placeholder="fort" name="carac2_group" id="carac2_group" value="<?php print $settings['carac2_group']; ?>">
+        </fieldset>
+        <fieldset>
+          <legend>Rôles</legend>
+          <label for="role_leader">Nom de rôle de leader</label>
+          <input type="text" name="role_leader" id="role_leader" maxlength="250" value="<?php print $settings['role_leader']; ?>">
+          <label for="role_traitre">Nom de rôle de traître</label>
+          <input type="text" name="role_traitre" id="role_traitre" maxlength="250" value="<?php print $settings['role_traitre']; ?>">
         </fieldset>
         <input type="submit" value="Enregistrer">
 

--- a/src/new.php
+++ b/src/new.php
@@ -18,6 +18,7 @@ if ($text == "erreur") {
     <span><label for="nom">Nom</label><input type="text" name="nom" id="nom" maxlength="15" required></span>
     <span><label for="pass">Mot de passe</label><input type="password" name="pass" id="pass" required></span>
   </fieldset>
+  <?php if ($settings['same_stats_all'] == FALSE) : ?>
   <fieldset>
     <legend>Votre type de personnage</legend>
     <span><input type="radio" name="stat" value="15_5"><?php print 'très ' . $settings['carac1_group'] . ' mais pas ' . $settings['carac2_group']; ?></span>
@@ -26,6 +27,7 @@ if ($text == "erreur") {
     <span><input type="radio" name="stat" value="8_12"><?php print 'peu ' . $settings['carac1_group'] . ' mais plutôt ' . $settings['carac2_group']; ?></span>
     <span><input type="radio" name="stat" value="5_15"><?php print 'pas ' . $settings['carac1_group'] . ' mais très ' . $settings['carac2_group']; ?></span>
   </fieldset>
+  <?php endif ?>
   <input class="submit-button" type="submit" value="Partir à l'aventure">
 </form>
 <?php

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -31,25 +31,69 @@ include 'header.php'; ?>
 <div>
   <?php
   if (empty($probleme)) {
-    $caracs = explode('_', $stat);
-    $carac1 = $caracs[0];
-    $carac2 = $caracs[1];
+    if ($settings['same_stats_all']) {
+      $carac1 = $carac2 = $hp = 10;
+    }
+    else {
+      $caracs = explode('_', $stat);
+      $carac1 = $caracs[0];
+      $carac2 = $caracs[1];
+      if (($carac1 + $carac2) > 20) {
+        $carac1 = $carac2 = 10;
+      }
+      $hp = 10 + rand(-2, 2);
+    }
 
-    $hp = 10 + rand(-2, 2);
-    $stmt = $db->prepare("SELECT id FROM tag WHERE category = 1 ORDER BY RAND()");
-    $stmt->execute();
-    $row = $stmt->fetch();
-    $tags[] = $row[0];
+    if ($settings['random_tags']) {
+      $stmt = $db->prepare("SELECT id FROM tag WHERE category = 1 ORDER BY RAND()");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
 
-    $stmt = $db->prepare("SELECT id FROM tag WHERE category = 2 ORDER BY RAND()");
-    $stmt->execute();
-    $row = $stmt->fetch();
-    $tags[] = $row[0];
+      $stmt = $db->prepare("SELECT id FROM tag WHERE category = 2 ORDER BY RAND()");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
 
-    $stmt = $db->prepare("SELECT id FROM tag WHERE category = 3 ORDER BY RAND()");
-    $stmt->execute();
-    $row = $stmt->fetch();
-    $tags[] = $row[0];
+      $stmt = $db->prepare("SELECT id FROM tag WHERE category = 3 ORDER BY RAND()");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
+    }
+    else {
+      $stmt = $db->prepare("
+      SELECT id, count(*) c FROM tag
+      RIGHT JOIN character_tag c ON c.`id_tag` = tag.id
+      WHERE tag.category = 1 
+      GROUP BY tag.id
+      ORDER BY c ASC
+      LIMIT 0,1");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
+
+      $stmt = $db->prepare("
+      SELECT id, count(*) c FROM tag
+      LEFT JOIN character_tag c ON c.`id_tag` = tag.id
+      WHERE tag.category = 2
+      GROUP BY tag.id
+      ORDER BY c ASC
+      LIMIT 0,1");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
+
+      $stmt = $db->prepare("
+      SELECT id, count(*) c FROM tag
+      LEFT JOIN character_tag c ON c.`id_tag` = tag.id
+      WHERE tag.category = 3
+      GROUP BY tag.id
+      ORDER BY c ASC
+      LIMIT 0,1");
+      $stmt->execute();
+      $row = $stmt->fetch();
+      $tags[] = $row[0];
+    }
 
     try {
       $stmt = $db->prepare("INSERT INTO hrpg (nom,mdp,carac2,carac1,hp,active) VALUES(:nom,:pass,:carac2,:carac1,:hp,:active)");

--- a/src/variables.php
+++ b/src/variables.php
@@ -10,28 +10,38 @@ if ($settings_timestamp == FALSE) {
   $settings_timestamp = time();
   file_put_contents($tmp_path . '/settings_timestamp.txt', $settings_timestamp);
 }
-$default_settings_set = [
-  'carac1_name' => 'esprit',
-  'carac2_name' => 'corps',
-  'carac1_group' => 'malin',
-  'carac2_group' => 'fort',
-  'adventure_name' => 'Notre Aventure',
-  'adventure_guide' => "Rejoindre l'Aventure : maspero.blue/rpg/ ou taper !aventure'",
-  'image_url' => './img/logo.png'
-];
 
 if (
-  !isset($settings) ||
+  !isset($_SESSION['settings']) ||
   !isset($_SESSION['current_timestamp']) ||
   $settings_timestamp > $_SESSION['current_timestamp']
 ) {
+  $default_settings_set = [
+    'carac1_name' => 'esprit',
+    'carac2_name' => 'corps',
+    'carac1_group' => 'malin',
+    'carac2_group' => 'fort',
+    'adventure_name' => 'Notre Aventure',
+    'adventure_guide' => "Rejoindre l'Aventure : ...'",
+    'role_leader' => 'leader',
+    'role_traitre' => 'traître',
+    'same_stats_all' => 0,
+    'random_tags' => 1
+  ];
   $settings_data = file_get_contents($tmp_path . '/settings.txt');
   $settings = unserialize($settings_data);
 
   foreach ($default_settings_set as $setting_key => $setting_value) {
-    if (!isset($settings[$setting_key]) || $settings[$setting_key] == '') {
+    if (!isset($settings[$setting_key]) || $settings[$setting_key] === "") {
       $settings[$setting_key] = $setting_value;
     }
   }
   $_SESSION['settings'] = $settings;
+  if ($_SESSION['id'] == 1) {
+    $_SESSION['current_timestamp'] = $settings_timestamp;
+  }
 }
+else {
+  $settings = $_SESSION['settings'];
+}
+


### PR DESCRIPTION
- L'écran d'admin générait une attribution inutile des paramètres de jeux à chaque check du timestamp, c'est fixé.
- On peut choisir que l'attribution des tags se fassent équitablement ou aléatoirement (valeur par défaut = aléatoire, modifiable dans l'écran des paramètres)
- On peut choisir un nom pour les rôles de leader et de traitre. Quelques icônes ont été supprimé pour être plus neutres dans la présentation de ces rôles.
- On peut choisir que les caractéristiques de tous les personnages soient égales à 10 sans choix possible au départ (cette option n'est pas cochée par défaut)

Désolé pour les sujets mélangés dans un seul commit, j'ai eu un problème d'historique avec mon fork, j'ai été obligé de détruire et forker à nouveau pour repartir proprement.