### PR TITLE
Suppression de warnings et notices

### DIFF
--- a/src/continuevalid.php
+++ b/src/continuevalid.php
@@ -4,18 +4,21 @@ $_SESSION['current_timestamp'] = 0;
 include "header.php";
 
 $cleanPost = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
-$nom = strtolower($cleanPost['nom']);
+isset($cleanPost['nom']) ? $nom = strtolower($cleanPost['nom']) : $nom = "";
 
 $stmt = $db->prepare("SELECT id,hp,mdp FROM hrpg WHERE nom=:nom");
 $stmt->execute([
   ':nom' => $nom,
 ]);
 $row = $stmt->fetch();
-$id = $row[0];
-$hp = $row[1];
-$mdp_hash = $row[2];
+$id = ""; $hp = ""; $mdp_hash = "";
+if ($stmt->rowCount() > 0) {
+  $id = $row[0];
+  $hp = $row[1];
+  $mdp_hash = $row[2];
+}
 
-$pass = $cleanPost['pass'];
+isset($cleanPost['pass']) ? $pass = $cleanPost['pass'] : $pass = "";
 if ($mdp_hash == '') {
   $pass = password_hash($pass, PASSWORD_DEFAULT);
   $stmt = $db->prepare("UPDATE hrpg SET mdp=:pass WHERE id=:id");

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -329,7 +329,7 @@ $settings = $_SESSION['settings'];
       <span>GAME TIMESTAMP : <?php print date('H:i:s', $game_timestamp); ?></span>
     </div>
   </div>
-  <?php print $_SESSION['sanction']; ?>
+  <?php if (isset($_SESSION['sanction'])) print $_SESSION['sanction']; ?>
   <div id="group">
     <?php
     $available_colors = ['#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231', '#911eb4', '#46f0f0', '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1', '#000075', '#808080'];

--- a/src/main.php
+++ b/src/main.php
@@ -5,9 +5,9 @@ $_SESSION['current_timestamp'] = 0;
 include 'header.php';
 
 $cleanPost = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
-$choix = $cleanPost['choix'];
-$lead = $cleanPost['lead'];
-$traitre = $cleanPost['traitre'];
+isset($cleanPost['choix']) ? $choix = $cleanPost['choix'] : $choix = "";
+isset($cleanPost['lead']) ? $lead = $cleanPost['lead'] : $lead = "";
+isset($cleanPost['traitre']) ? $traitre = $cleanPost['traitre'] : $traitre = "";
 
 $id = $_SESSION['id'];
 if ($choix != "") {

--- a/src/new.php
+++ b/src/new.php
@@ -3,8 +3,9 @@ session_start();
 $page_id = 'page-new';
 $_SESSION['current_timestamp'] = 0;
 include 'header.php';
-$text = $_GET['text'];
+isset($_GET['text']) ? $text = $_GET['text'] : $text = "";
 
+$erreur = "";
 if ($text == "erreur") {
   $erreur = "<div>Ce héros existe déjà ! Merci d'utiliser « Reprendre une partie ».<br>
   Si malheureusement vous êtes mort, nous vous invitons à créer un nouveau personnage.</div>";

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -2,9 +2,9 @@
 session_start();
 include "connexion.php";
 
-$nom = $_POST['nom'];
-$pass = $_POST['pass'];
-$stat = $_POST['stat'];
+isset($_POST['nom']) ? $nom = $_POST['nom'] : $nom = "";
+isset($_POST['pass']) ? $pass = $_POST['pass'] : $pass = "";
+isset($_POST['stat']) ? $stat = $_POST['stat'] : $stat = "";
 $probleme = NULL;
 
 if (empty($nom) || empty($pass)) {
@@ -21,9 +21,7 @@ else {
           ':nom' => $nom,
   ]);
 
-  $row = $stmt->fetch();
-  $id = $row[0];
-  if (!empty($id)) {
+  if ($stmt->rowCount() > 0) {
     $probleme = 'Ce nom est déjà utilisé. Veuillez en choisir un autre.';
   }
 }
@@ -44,21 +42,28 @@ include 'header.php'; ?>
       $hp = 10 + rand(-2, 2);
     }
 
+    $tags[] = null;
     if ($settings['random_tags']) {
       $stmt = $db->prepare("SELECT id FROM tag WHERE category = 1 ORDER BY RAND()");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
 
       $stmt = $db->prepare("SELECT id FROM tag WHERE category = 2 ORDER BY RAND()");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
 
       $stmt = $db->prepare("SELECT id FROM tag WHERE category = 3 ORDER BY RAND()");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
     }
     else {
       $stmt = $db->prepare("
@@ -69,8 +74,10 @@ include 'header.php'; ?>
       ORDER BY c ASC
       LIMIT 0,1");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
 
       $stmt = $db->prepare("
       SELECT id, count(*) c FROM tag
@@ -80,8 +87,10 @@ include 'header.php'; ?>
       ORDER BY c ASC
       LIMIT 0,1");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
 
       $stmt = $db->prepare("
       SELECT id, count(*) c FROM tag
@@ -91,8 +100,10 @@ include 'header.php'; ?>
       ORDER BY c ASC
       LIMIT 0,1");
       $stmt->execute();
-      $row = $stmt->fetch();
-      $tags[] = $row[0];
+      if ($stmt->rowCount() > 0) {
+        $row = $stmt->fetch();
+        $tags[] = $row[0];
+      }
     }
 
     try {

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -42,7 +42,7 @@ include 'header.php'; ?>
       $hp = 10 + rand(-2, 2);
     }
 
-    $tags[] = null;
+    $tags = [];
     if ($settings['random_tags']) {
       $stmt = $db->prepare("SELECT id FROM tag WHERE category = 1 ORDER BY RAND()");
       $stmt->execute();

--- a/src/variables.php
+++ b/src/variables.php
@@ -42,7 +42,7 @@ if (
     }
   }
   $_SESSION['settings'] = $settings;
-  if ($_SESSION['id'] == 1) {
+  if (isset($_SESSION['id']) && $_SESSION['id'] == 1) {
     $_SESSION['current_timestamp'] = $settings_timestamp;
   }
 }

--- a/src/variables.php
+++ b/src/variables.php
@@ -28,8 +28,13 @@ if (
     'same_stats_all' => 0,
     'random_tags' => 1
   ];
-  $settings_data = file_get_contents($tmp_path . '/settings.txt');
-  $settings = unserialize($settings_data);
+  if (file_exists($tmp_path . '/settings.txt')) {
+    $settings_data = file_get_contents($tmp_path . '/settings.txt');
+    $settings = unserialize($settings_data);
+  }
+  else {
+    print "<!-- Fichier tmp/settings.txt inexistant -->";
+  }
 
   foreach ($default_settings_set as $setting_key => $setting_value) {
     if (!isset($settings[$setting_key]) || $settings[$setting_key] === "") {


### PR DESCRIPTION
Quand on établit le niveau de renvoi d'erreurs à un seuil sensible, le site renvoie sur plusieurs pages des notices et warnings en raison principalement de variables non définies au moment où elles sont testées. Cette mise à jour corriger ces points sur 5 pages (rien vu d'autres en naviguant en tant que MJ et en créant un personnage, mais je n'arrive pas encore à voir une page PJ connectée sur mon poste).

J'ai fait pas mal de tests et ça me semble ok, mais je ne connais pas encore très bien tous les recoins du site :p