### PR TITLE
Ajout de 3eme carac et d'une 2e barre de vie (points de volonté)

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -4,10 +4,6 @@
 #
 # http://www.sequelpro.com/
 # https://github.com/sequelpro/sequelpro
-#
-# Hôte: localhost (MySQL 5.7.26)
-# Base de données: atrpg_bigbase
-# Temps de génération: 2021-02-15 01:59:58 +0000
 # ************************************************************
 
 
@@ -42,9 +38,11 @@ CREATE TABLE `hrpg` (
   `id` int(15) unsigned NOT NULL AUTO_INCREMENT,
   `nom` mediumtext NOT NULL,
   `mdp` mediumtext NOT NULL,
+  `carac3` tinyint(1) NOT NULL,
   `carac2` tinyint(1) NOT NULL,
   `carac1` tinyint(1) NOT NULL,
   `hp` tinyint(1) NOT NULL,
+  `wp` tinyint(1) NOT NULL,
   `leader` tinyint(1) NOT NULL DEFAULT '0',
   `traitre` tinyint(1) NOT NULL DEFAULT '0',
   `vote` tinyint(1) NOT NULL DEFAULT '0',

--- a/src/ajax.php
+++ b/src/ajax.php
@@ -134,9 +134,11 @@ elseif ($_GET['role'] == 'pj') {
   $row = $query_player->fetch(PDO::FETCH_ASSOC);
   $id = $row['id'];
   $nom = $row['nom'];
+  $carac3 = $row['carac3'];
   $carac2 = $row['carac2'];
   $carac1 = $row['carac1'];
   $hp = $row['hp'];
+  $wp = $row['wp'];
   $leader = $row['leader'];
   $vote = $row['vote'];
   $traitre = $row['traitre'];
@@ -155,9 +157,21 @@ elseif ($_GET['role'] == 'pj') {
   $results_tags = $query_tags->fetchAll(PDO::FETCH_KEY_PAIR);
 ?>
 
-<h2>Votre aventurier</h2>
+<h2>Votre personnage</h2>
 <?php
-if ($hp > 0) { ?>
+$still_ok = true;
+if ($hp <= 0) {
+  $still_ok = false;
+  $ko_icon = '☠';
+  $ko_message = "Votre personnage $nom est mort.";
+}
+elseif ($settings['willpower_on'] && $wp <= 0) {
+  $still_ok = false;
+  $ko_icon = '🌑';
+  $ko_message = "Votre personnage $nom a sombré.";
+}
+
+if ($still_ok) { ?>
   <div class="character">
     <div class="character-name"><?php print $nom; ?></div>
     <div class="character-tags">
@@ -170,7 +184,15 @@ if ($hp > 0) { ?>
     <div class="character-stats">
       <div><?php print $settings['carac1_name']; ?> : <b><?php print $carac1; ?></b></div>
       <div><?php print $settings['carac2_name']; ?> : <b><?php print $carac2; ?></b></div>
-      <div>💛 Points de vie : <b><?php print $hp; ?></b></div>
+      <?php if ($settings['carac3_name'] != "") { ?>
+      <div><?php print $settings['carac3_name']; ?> : <b><?php print $carac3; ?></b></div>
+      <?php } ?>
+      <div>💛 Pts de vie : <b><?php print $hp; ?></b></div>
+      <?php
+        if ($settings['willpower_on'] != "") {
+          print "<div>🌟 Pts de volonté : <b>" . $wp ."</b></div>";
+        }
+      ?>
     </div>
     <?php if ($leader > 0) { ?>
       <div class="pj-role">Vous êtes actuellement <b><?php print $settings['role_leader']; ?></b> !</div>
@@ -250,7 +272,7 @@ if ($hp > 0) { ?>
       <?php
       foreach ($loot as $key => $row) {
         $quoi = $row[0];
-        print "<br>- $quoi";
+        print "<br />$quoi";
       }
     }
     ?>
@@ -258,8 +280,8 @@ if ($hp > 0) { ?>
   <?php
   }
   else { ?>
-    <div class="wakeup">☠</div>
-    <div><?php print "Votre personnage $nom est mort"; ?></div>
+    <div class="wakeup"><?php print $ko_icon; ?></div>
+    <div><?php print $ko_message; ?></div>
 <?php
   }
 }

--- a/src/continuevalid.php
+++ b/src/continuevalid.php
@@ -6,7 +6,7 @@ include "header.php";
 $cleanPost = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
 isset($cleanPost['nom']) ? $nom = strtolower($cleanPost['nom']) : $nom = "";
 
-$stmt = $db->prepare("SELECT id,hp,mdp FROM hrpg WHERE nom=:nom");
+$stmt = $db->prepare("SELECT id,hp,wp,mdp FROM hrpg WHERE nom=:nom");
 $stmt->execute([
   ':nom' => $nom,
 ]);
@@ -15,7 +15,8 @@ $id = ""; $hp = ""; $mdp_hash = "";
 if ($stmt->rowCount() > 0) {
   $id = $row[0];
   $hp = $row[1];
-  $mdp_hash = $row[2];
+  $wp = $row[2];
+  $mdp_hash = $row[3];
 }
 
 isset($cleanPost['pass']) ? $pass = $cleanPost['pass'] : $pass = "";
@@ -41,15 +42,20 @@ if ($id != "") {
     $link = 'Accédez à l\'écran du MJ en cliquant <a href=ecran.php>ici</a>';
   }
   else {
-    if ($hp > 0) {
+    if ($hp <= 0) {
+      $text = 'Votre personnage est mort ☠️. On en recrée un nouveau ?';
+      $link = "Retourner au <a href=index.php>menu principal</a>";
+      
+    }
+    elseif ($settings['willpower_on'] && $wp <= 0) {
+      $text = 'Votre personnage a sombré 🌑️. On en recrée un nouveau ?';
+      $link = "Retourner au <a href=index.php>menu principal</a>";
+    }
+    else {
       $stmt = $db->prepare("UPDATE hrpg SET active=1 WHERE id = :id");
       $stmt->execute([':id' => $id]);
       $text = 'Votre grande aventure continue';
       $link = 'Cliquez <a href=main.php>ici</a>';
-    }
-    else {
-      $text = 'Votre personnage est mort ☠️. On en recrée un nouveau ?';
-      $link = "Retourner au <a href=index.php>menu principal</a>";
     }
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -106,6 +106,12 @@ h3 {
   box-shadow: 0 0 3px lightgray;
   border: 1px solid lightgray;
 }
+hr {
+    border: 0;
+    border-top: 1px solid #ddd;
+    margin: 0.1em 0;
+    padding: 0;
+}
 .theme-switch {
   margin-right: 10px;
   display: flex;
@@ -244,10 +250,19 @@ body .index-wrapper a {
   display: flex;
   flex-direction: column;
   flex: 1;
+  text-align: center;
+}
+.stats > .aptitude {
+  font-size: small;
+}
+.stats > .caracs {
+  font-size: x-small;
 }
 .stats > .life {
+  font-size: x-small;
   margin-top: auto;
 }
+
 .stats, .tags {
   margin-top: 5px;
 }

--- a/src/ecran.php
+++ b/src/ecran.php
@@ -40,7 +40,7 @@ if (isset($_GET['action'])) {
 
     $db->query(
       "INSERT INTO `hrpg`"
-      . " (`nom`, `mdp`, `carac2`, `carac1`, `hp`, `leader`, `traitre`, `vote`, `log`, `lastlog`, `status`)"
+      . " (`nom`, `mdp`, `carac3`, `carac2`, `carac1`, `hp`, `wp`, `leader`, `traitre`, `vote`, `log`, `lastlog`, `status`)"
       . " VALUES ('" . $hash . "', '', '1', '1', '1', '0', '0', '0', '', '', '', NULL, NULL, 1)"
     );
   }

--- a/src/new.php
+++ b/src/new.php
@@ -22,11 +22,42 @@ if ($text == "erreur") {
   <?php if ($settings['same_stats_all'] == FALSE) : ?>
   <fieldset>
     <legend>Votre type de personnage</legend>
-    <span><input type="radio" name="stat" value="15_5"><?php print 'très ' . $settings['carac1_group'] . ' mais pas ' . $settings['carac2_group']; ?></span>
-    <span><input type="radio" name="stat" value="12_8"><?php print 'plutôt ' . $settings['carac1_group'] . ' mais peu ' . $settings['carac2_group']; ?></span>
-    <span><input type="radio" name="stat" value="10_10"><?php print 'équilibré'; ?></span>
-    <span><input type="radio" name="stat" value="8_12"><?php print 'peu ' . $settings['carac1_group'] . ' mais plutôt ' . $settings['carac2_group']; ?></span>
-    <span><input type="radio" name="stat" value="5_15"><?php print 'pas ' . $settings['carac1_group'] . ' mais très ' . $settings['carac2_group']; ?></span>
+    <?php if ($_SESSION['settings']['carac3_name'] != "") { ?>
+    <span>
+      <input type="radio" name="stat" value="9_9_9">équilibré
+    </span>
+    <span>
+      <input type="radio" name="stat" value="12_6_6">orienté <?php print $settings['carac1_group']; ?>
+    </span>
+    <span>
+      <input type="radio" name="stat" value="6_12_6">orienté <?php print $settings['carac2_group']; ?>
+    </span>
+    <span>
+      <input type="radio" name="stat" value="6_6_12">orienté <?php print $settings['carac3_group']; ?>
+    </span>
+    <?php
+    }
+    else {
+    ?>
+    <span>
+      <input type="radio" name="stat" value="15_5_10"><?php print 'très ' . $settings['carac1_group'] . ' mais pas ' . $settings['carac2_group']; ?>
+    </span>
+    <span>
+      <input type="radio" name="stat" value="12_8_10"><?php print 'plutôt ' . $settings['carac1_group'] . ' mais peu ' . $settings['carac2_group']; ?>
+    </span>
+    <span>
+      <input type="radio" name="stat" value="10_10_10">équilibré
+    </span>
+    <span>
+      <input type="radio" name="stat" value="8_12_10"><?php print 'peu ' . $settings['carac1_group'] . ' mais plutôt ' . $settings['carac2_group']; ?>
+    </span>
+    <span>
+      <input type="radio" name="stat" value="5_15_10"><?php print 'pas ' . $settings['carac1_group'] . ' mais très ' . $settings['carac2_group']; ?>
+    </span>
+    <?php
+    }
+    ?>
+
   </fieldset>
   <?php endif ?>
   <input class="submit-button" type="submit" value="Partir à l'aventure">

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -30,7 +30,7 @@ include 'header.php'; ?>
   <?php
   if (empty($probleme)) {
     if ($settings['same_stats_all']) {
-      $carac1 = $carac2 = $hp = 10;
+      $carac1 = $carac2 = $carac3 = $hp = $wp = 10;
     }
     else {
       $caracs = explode('_', $stat);
@@ -189,7 +189,7 @@ include 'header.php'; ?>
     ?>
     <div>Impossible de créer votre personnage 😢.</div>
     <div><?php print $probleme; ?></div>
-    <div><a href=new.php>Réessayez</a> ou retournez <a href=index.php>au menu principal</a></div>
+    <div><a href=new.php>Réessayez</a> ou retournez <a href=index.php>au menu principal.</a></div>
     <?php
   }
   ?>

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -36,10 +36,50 @@ include 'header.php'; ?>
       $caracs = explode('_', $stat);
       $carac1 = $caracs[0];
       $carac2 = $caracs[1];
-      if (($carac1 + $carac2) > 20) {
-        $carac1 = $carac2 = 10;
+      $carac3 = $caracs[2]; // définie à 10 par défaut même si 2 caracs
+      
+      if ($_SESSION['settings']['carac3_name'] != "") {
+        if ($carac3 == 9) {
+          // Personnage équilibré
+          // Chaque carac peut aller de 9 à 11
+          
+          // Protection triche
+          if (($carac1 + $carac2 + $carac3) > 27) {
+            $carac1 = $carac2 = $carac3 = 9;
+          }
+          
+          // Tirage des caracs
+          $tirage_carac = array(0, 1, 1, 2);
+          shuffle($tirage_carac);
+          $carac1 = $carac1 + $tirage_carac[0];
+          $carac2 = $carac2 + $tirage_carac[1];
+          $carac3 = 30 - ( $carac1 + $carac2);
+        }
+        else {
+          // Personnage spécialisé
+          
+          // Protection triche
+          if (($carac1 + $carac2 + $carac3) > 24) {
+            $carac1 = $carac2 = $carac3 = 8;
+          }
+          
+          // Tirage des caracs
+          $tirage_carac = array(0, 1, 1, 2, 2, 2, 3, 3, 4);
+          shuffle($tirage_carac);
+          $carac1 = $carac1 + $tirage_carac[0];
+          $carac2 = $carac2 + $tirage_carac[1];
+          $carac3 = 30 - ( $carac1 + $carac2);
+        }
       }
+      else {
+        // 2 caracs : protection triche
+        if (($carac1 + $carac2) > 20) {
+          $carac1 = $carac2 = $carac3 = 10;
+        }
+      }
+      
       $hp = 10 + rand(-2, 2);
+      $wp = 20 - $hp + rand(-1, 1);
     }
 
     $tags = [];
@@ -107,13 +147,15 @@ include 'header.php'; ?>
     }
 
     try {
-      $stmt = $db->prepare("INSERT INTO hrpg (nom,mdp,carac2,carac1,hp,active) VALUES(:nom,:pass,:carac2,:carac1,:hp,:active)");
+      $stmt = $db->prepare("INSERT INTO hrpg (nom,mdp,carac3,carac2,carac1,hp,wp,active) VALUES(:nom,:pass,:carac3,:carac2,:carac1,:hp,:wp,:active)");
       $stmt->execute([
         ':nom' => $nom,
         ':pass' => $pass,
+        ':carac3' => $carac3,
         ':carac2' => $carac2,
         ':carac1' => $carac1,
         ':hp' => $hp,
+        ':wp' => $wp,
         ':active' => 1
       ]);
       $id = $db->lastInsertId();

--- a/src/variables.php
+++ b/src/variables.php
@@ -19,14 +19,17 @@ if (
   $default_settings_set = [
     'carac1_name' => 'esprit',
     'carac2_name' => 'corps',
+    'carac3_name' => '',
     'carac1_group' => 'malin',
     'carac2_group' => 'fort',
+    'carac3_group' => '',
     'adventure_name' => 'Notre Aventure',
     'adventure_guide' => "Rejoindre l'Aventure : ...'",
     'role_leader' => 'leader',
     'role_traitre' => 'traître',
     'same_stats_all' => 0,
-    'random_tags' => 1
+    'random_tags' => 1,
+    'willpower_on' => 0
   ];
   if (file_exists($tmp_path . '/settings.txt')) {
     $settings_data = file_get_contents($tmp_path . '/settings.txt');


### PR DESCRIPTION
Ajout de carac3 et wp.
Si le nom de la 3e carac est laissé vide, elle est ignorée.
L'activation de la jauge "volonté" se fait par case à cocher dans les paramètres.
Si un personnage tombe à 0wp il est éliminé comme s'il était tombé à 0hp. L'icône qui le représente est différente.. sauf sur la page "Groupe" où c'est géré dans du CSS non adaptable mais ce n'est pas bien grave, le skull continuera pour l'instant de représenter le hors jeu.

Pour la création de perso, j'ai mis de l'aléatoire dans les stats, je n'ai pas encore touché aux histoires de slides JS histoire de ne pas avoir un pull trop gros et compliqué à tester (c'est déjà un peu le cas...).

 + correctifs mineurs au passage (notamment sur les messages confirmant la perte de stats après une épreuve ratée, ou l'emplacement dans le code de l'info "tags_players")

+ un TODO ajouté sur un code qui ne me semble jamais atteint (mais je manque de recul pour juger)

J'ai fait pas mal de tests et ça semble ok, mais tout ça impacte de nombreuses pages avec pas mal de code réparti ici et là, donc il doit bien rester de petits bugs.