### PR TITLE
Destitutions / Restrictions aux actifs / etc

### DIFF
--- a/src/admin_tools.php
+++ b/src/admin_tools.php
@@ -61,6 +61,7 @@ function save_new_settings($post, $tmp_path) {
   $_SESSION['settings']['same_stats_all'] = isset($post['same_stats_all']);
   $_SESSION['settings']['random_tags'] = isset($post['random_tags']);
   $_SESSION['settings']['willpower_on'] = isset($post['willpower_on']);
+  $_SESSION['settings']['restrict_active'] = isset($post['restrict_active']);
   save_in_file($tmp_path . '/settings.txt', serialize($_SESSION['settings']));
   save_in_file($tmp_path . '/settings_timestamp.txt', time());
   save_in_file($tmp_path . '/game_timestamp.txt', time());
@@ -175,30 +176,40 @@ function add_new_tags($db, $post) {
  *
  * @return string
  */
-function generate_target_query_part($type = 'all', $data) {
+function generate_target_query_part($type = 'all', $data, $only_active) {
+  $option_active = '';
+  if ($only_active) {
+    $option_active = ' AND active = 1';
+  }
+  
   if ($type == 'tags' && !empty($data)) {
     return 'LEFT JOIN character_tag ct ON ct.id_player = hrpg.id' .
-      ' WHERE ct.id_tag IN (' . implode(',', array_keys($data)) . ') AND hp > 0 AND wp > 0';
+      ' WHERE ct.id_tag IN (' . implode(',', array_keys($data)) . ') AND hp > 0 AND wp > 0' . $option_active;
   }
   elseif ($type == 'players' && !empty($data)) {
-    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND id IN(' . implode(',', array_keys($data)) . ')';
+    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND id IN(' . implode(',', array_keys($data)) . ')' . $option_active;
   }
   elseif ($type == 'all') {
-    return 'WHERE id > 1 AND hp > 0 AND wp > 0';
+    return 'WHERE id > 1 AND hp > 0 AND wp > 0' . $option_active;
   }
   elseif ($type == 'carac1') {
-    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac1 > 14';
+    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac1 > 14' . $option_active;
   }
   elseif ($type == 'carac2') {
-    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac2 > 14';
+    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac2 > 14' . $option_active;
   }
   elseif ($type == 'carac3') {
-    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac3 > 14';
+    return 'WHERE id > 1 AND hp > 0 AND wp > 0 AND carac3 > 14' . $option_active;
   }
   return FALSE;
 }
 
 function update_events($db, $post) {
+  $only_active = 0;
+  if (isset($post['restrict_active'])) {
+    $only_active = 1;
+  }
+
   $data = [];
   if (!empty($post['victimetag'])) {
     $data = decode_tags($post['victimetag']);
@@ -215,7 +226,7 @@ function update_events($db, $post) {
   $users = $db->query(
     'SELECT ' . $post['type'] . ',id,' . $post['penalite_type']
     . ' FROM hrpg '
-    . generate_target_query_part($type_target, $data)
+    . generate_target_query_part($type_target, $data, $only_active)
   );
   $loosers = $winners = $failures = $success = [];
   foreach ($users->fetchAll(PDO::FETCH_ASSOC) as $key => $user) {
@@ -293,6 +304,11 @@ function update_events($db, $post) {
 
 function gen_loot_query_part($post) {
   $str = '';
+  $option_active = '';
+  if (isset($post['restrict_active'])) {
+    $option_active = ' AND active = 1';
+  }
+  
   if (!empty($post['qui_multiple'])) {
     $data = decode_tags($post['qui_multiple']);
     $keys = implode(',', array_keys($data));
@@ -312,16 +328,16 @@ function gen_loot_query_part($post) {
       $str = ' WHERE ';
     }
     if ($post['qui'] == 'all') {
-      $str .= 'hp > 0 AND wp > 0 AND id > 1';
+      $str .= 'hp > 0 AND wp > 0 AND id > 1' . $option_active;
     }
     elseif ($post['qui'] == 'carac1') {
-      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac1 > 14';
+      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac1 > 14' . $option_active;
     }
     elseif ($post['qui'] == 'carac2') {
-      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac2 > 14';
+      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac2 > 14' . $option_active;
     }
     elseif ($post['qui'] == 'carac3') {
-      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac3 > 14';
+      $str .= 'hp > 0 AND wp > 0 AND id > 1 AND carac3 > 14' . $option_active;
     }
   }
   return $str;

--- a/src/admin_tools.php
+++ b/src/admin_tools.php
@@ -62,6 +62,7 @@ function save_new_settings($post, $tmp_path) {
   $_SESSION['settings']['random_tags'] = isset($post['random_tags']);
   $_SESSION['settings']['willpower_on'] = isset($post['willpower_on']);
   $_SESSION['settings']['restrict_active'] = isset($post['restrict_active']);
+  $_SESSION['settings']['lock_new'] = isset($post['lock_new']);
   save_in_file($tmp_path . '/settings.txt', serialize($_SESSION['settings']));
   save_in_file($tmp_path . '/settings_timestamp.txt', time());
   save_in_file($tmp_path . '/game_timestamp.txt', time());

--- a/src/ajax.php
+++ b/src/ajax.php
@@ -89,6 +89,7 @@ elseif ($_GET['role'] == 'mj' && $_SESSION['id'] == 1) {
     print "<div class='poll-action traitor-action'>" . $settings['role_traitre'] . " $traitre a utilisé son pouvoir et annule un choix.</div>";
   }
 
+  $vote_results_total = '<table>';
   foreach ($votes as $key => $vote) {
     $nb_votants = $vote['c'];
     
@@ -106,7 +107,9 @@ elseif ($_GET['role'] == 'mj' && $_SESSION['id'] == 1) {
     if (isset($traitrevalue) && $traitrevalue == 2 && $vote['vote'] == $traitrevote) {
        $classes[] = 'traitor-vote';
     }
-    print "<tr class=\"" . implode(' ', $classes) . "\"><td>" . $options['c' . $vote['vote']] . " : </td><td>$nb_votants / $nb_total soit $pc %</td></tr>";
+    $vote_results_line = "<tr class=\"" . implode(' ', $classes) . "\"><td>" . $options['c' . $vote['vote']] . " : </td><td>$nb_votants / $nb_total soit $pc %</td></tr>";
+    print $vote_results_line;
+    $vote_results_total .= $vote_results_line;
     unset($options['c' . $vote['vote']]);
   }
   foreach ($options as $option) {
@@ -115,6 +118,7 @@ elseif ($_GET['role'] == 'mj' && $_SESSION['id'] == 1) {
     }
   }
   print "</table>";
+  $_SESSION['last_vote'] = $vote_results_total . '</table>';
   if ($nb_total > 0) {
     print "<div>Total votants : " . round(($pctot * 100 / $nb_total), 2) . "%</div>";
   }

--- a/src/continue.php
+++ b/src/continue.php
@@ -5,4 +5,6 @@
   <label for="nom">Mot de passe :</label><input type="password" name="pass" size=24">
   <input class="submit-button" type="submit" value="Continuer l'Aventure">
 </form>
+<br />
+<a href="index.php">Retour</a>
 <?php include "footer.php"; ?>

--- a/src/ecran.php
+++ b/src/ecran.php
@@ -12,7 +12,7 @@ unset($_SESSION['designe']);
 
 if (isset($_GET['action'])) {
   require "variables.php";
-  $_POST = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);;
+  $_POST = filter_input_array(INPUT_POST, FILTER_SANITIZE_STRING);
 
   // SUPPRESSION DE L'AVENTURE
   if ($_GET['action'] == "delete") {
@@ -60,8 +60,12 @@ if (isset($_GET['action'])) {
     poll_update($db, $_POST);
   }
   // TRAITEMENT DES NOMINATIONS.
-  elseif ($_GET['action'] == 'election') {
+  elseif ($_GET['action'] == "election") {
     make_election($db, $_POST);
+  }
+  // TRAITEMENT DES DESTITUTIONS.
+  elseif ($_GET['action'] == "destitution") {
+    remove_role($db, $_POST);
   }
   // TRAITEMENT DES NOMINATIONS.
   elseif ($_GET['action'] == 'target') {

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -147,6 +147,10 @@ $settings = $_SESSION['settings'];
             <input class="tag-whitelist" type="text" name="choixtag" id="choixtag" maxlength="250" placeholder="Entrez un tag">
           </fieldset>
           <input type="submit" value="Délibérer">
+          <fieldset>
+            <legend>Rappel du dernier sondage</legend>
+            <?php print $_SESSION['last_vote']; ?>
+          </fieldset>
         </form>
         <?php
       }

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -390,6 +390,11 @@ $settings = $_SESSION['settings'];
             <label for="restrict_active">Restreindre aux actifs par défaut</label>
             <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
           </div>
+          <br />
+          <div>
+            <label for="lock_new">Verrouiller les créations de personnage</label>
+            <input type="checkbox" name="lock_new" id="lock_new" <?php print ($settings['lock_new'] ? 'checked' : ''); ?>>
+          </div>
         </fieldset>
         
         <input type="submit" value="Enregistrer">

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -76,6 +76,10 @@ $settings = $_SESSION['settings'];
         <button name="name" value="leader" type="submit">Nommer <?php print $settings['role_leader']; ?></button>
         <button name="name" value="traitre" type="submit">Nommer <?php print $settings['role_traitre']; ?></button>
       </form>
+      <form method="post" action="ecran.php?action=destitution" style="margin-top: 10px">
+        <button name="name" value="leader" type="submit">Destituer <?php print $settings['role_leader']; ?></button>
+        <button name="name" value="traitre" type="submit">Destituer <?php print $settings['role_traitre']; ?></button>
+      </form>
     </div>
     <!-- FORMULAIRE DESIGNATION -->
     <div id="target" class="active">

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -238,6 +238,10 @@ $settings = $_SESSION['settings'];
             <label for="victimetag"><strong>Ou</strong> par Tag</label>
             <input class="tag-whitelist" type="text" name="victimetag" placeholder="Entrez un tag"  id="victimetag" maxlength="250">
           </span>
+          <span class="wrapper-penalite">
+            Limiter aux personnages actifs :
+            <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
+          </span>
         </fieldset>
         <input type="submit" value="ÉPROUVER">
       </form>
@@ -292,6 +296,8 @@ $settings = $_SESSION['settings'];
             </select>
             <label for="qui_tags"><strong>ayant</strong> au moins un des tags</label>
             <input class="tag-whitelist" type="text" name="qui_tags" placeholder="Entrez un tag"  id="qui_tags" maxlength="250">
+            Limiter aux personnages actifs :
+            <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
           </span>
         </fieldset>
         <fieldset>
@@ -369,6 +375,9 @@ $settings = $_SESSION['settings'];
           
           <label for="willpower_on">Jauge de volonté</label>
           <input type="checkbox" name="willpower_on" id="willpower_on" <?php print ($settings['willpower_on'] ? 'checked' : ''); ?>>
+          
+          <label for="restrict_active">Restreindre aux personnages actifs par défaut</label>
+          <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
         </fieldset>
         
         <input type="submit" value="Enregistrer">

--- a/src/ecran_forms.php
+++ b/src/ecran_forms.php
@@ -296,7 +296,7 @@ $settings = $_SESSION['settings'];
             </select>
             <label for="qui_tags"><strong>ayant</strong> au moins un des tags</label>
             <input class="tag-whitelist" type="text" name="qui_tags" placeholder="Entrez un tag"  id="qui_tags" maxlength="250">
-            Limiter aux personnages actifs :
+            <label for="restrict_active">Limiter aux personnages actifs :</label>
             <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
           </span>
         </fieldset>
@@ -365,19 +365,27 @@ $settings = $_SESSION['settings'];
         </fieldset>
         
         
-        <fieldset>
+        <fieldset style="text-align: left">
           <legend>Autres paramètres</legend>
-          <label for="same_stats_all">Mêmes stats pour tout le monde</label>
-          <input type="checkbox" name="same_stats_all" id="same_stats_all" <?php print ($settings['same_stats_all'] ? 'checked' : ''); ?>>
-          
-          <label for="random_tags">Tags distribués aléatoirement</label>
-          <input type="checkbox" name="random_tags" id="random_tags" <?php print ($settings['random_tags'] ? 'checked' : ''); ?>>
-          
-          <label for="willpower_on">Jauge de volonté</label>
-          <input type="checkbox" name="willpower_on" id="willpower_on" <?php print ($settings['willpower_on'] ? 'checked' : ''); ?>>
-          
-          <label for="restrict_active">Restreindre aux personnages actifs par défaut</label>
-          <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
+          <div>
+            <label for="same_stats_all">Mêmes stats pour tout le monde</label>
+            <input type="checkbox" name="same_stats_all" id="same_stats_all" <?php print ($settings['same_stats_all'] ? 'checked' : ''); ?>>
+          </div>
+          <br />
+          <div>
+            <label for="random_tags">Tags distribués aléatoirement</label>
+            <input type="checkbox" name="random_tags" id="random_tags" <?php print ($settings['random_tags'] ? 'checked' : ''); ?>>
+          </div>
+          <br />
+          <div>
+            <label for="willpower_on">Jauge de volonté</label>
+            <input type="checkbox" name="willpower_on" id="willpower_on" <?php print ($settings['willpower_on'] ? 'checked' : ''); ?>>
+          </div>
+          <br />
+          <div>
+            <label for="restrict_active">Restreindre aux actifs par défaut</label>
+            <input type="checkbox" name="restrict_active" id="restrict_active" <?php print ($settings['restrict_active'] ? 'checked' : ''); ?>>
+          </div>
         </fieldset>
         
         <input type="submit" value="Enregistrer">

--- a/src/new.php
+++ b/src/new.php
@@ -5,63 +5,68 @@ $_SESSION['current_timestamp'] = 0;
 include 'header.php';
 isset($_GET['text']) ? $text = $_GET['text'] : $text = "";
 
-$erreur = "";
-if ($text == "erreur") {
-  $erreur = "<div>Ce héros existe déjà ! Merci d'utiliser « Reprendre une partie ».<br>
-  Si malheureusement vous êtes mort, nous vous invitons à créer un nouveau personnage.</div>";
+if ($_SESSION['settings']['lock_new']) {
+  print "<h2>Création de personnage</h2>";
+  print "<br />";
+  print "L'aventure n'accueille pas de nouveaux personnages pour l'instant !<br />";
+  print "<br />";
 }
-?>
-<form method="post" action="newcomplete.php">
-  <?php print $erreur; ?>
-  <h2>Création de personnage</h2>
-  <fieldset>
-    <legend>La base</legend>
-    <span><label for="nom">Nom</label><input type="text" name="nom" id="nom" maxlength="15" required></span>
-    <span><label for="pass">Mot de passe</label><input type="password" name="pass" id="pass" required></span>
-  </fieldset>
-  <?php if ($settings['same_stats_all'] == FALSE) : ?>
-  <fieldset>
-    <legend>Votre type de personnage</legend>
-    <?php if ($_SESSION['settings']['carac3_name'] != "") { ?>
-    <span>
-      <input type="radio" name="stat" value="9_9_9">équilibré
-    </span>
-    <span>
-      <input type="radio" name="stat" value="12_6_6">orienté <?php print $settings['carac1_group']; ?>
-    </span>
-    <span>
-      <input type="radio" name="stat" value="6_12_6">orienté <?php print $settings['carac2_group']; ?>
-    </span>
-    <span>
-      <input type="radio" name="stat" value="6_6_12">orienté <?php print $settings['carac3_group']; ?>
-    </span>
-    <?php
-    }
-    else {
-    ?>
-    <span>
-      <input type="radio" name="stat" value="15_5_10"><?php print 'très ' . $settings['carac1_group'] . ' mais pas ' . $settings['carac2_group']; ?>
-    </span>
-    <span>
-      <input type="radio" name="stat" value="12_8_10"><?php print 'plutôt ' . $settings['carac1_group'] . ' mais peu ' . $settings['carac2_group']; ?>
-    </span>
-    <span>
-      <input type="radio" name="stat" value="10_10_10">équilibré
-    </span>
-    <span>
-      <input type="radio" name="stat" value="8_12_10"><?php print 'peu ' . $settings['carac1_group'] . ' mais plutôt ' . $settings['carac2_group']; ?>
-    </span>
-    <span>
-      <input type="radio" name="stat" value="5_15_10"><?php print 'pas ' . $settings['carac1_group'] . ' mais très ' . $settings['carac2_group']; ?>
-    </span>
-    <?php
-    }
-    ?>
+else {
+  ?>
+  <form method="post" action="newcomplete.php">
+    <h2>Création de personnage</h2>
+    <fieldset>
+      <legend>La base</legend>
+      <span><label for="nom">Nom</label><input type="text" name="nom" id="nom" maxlength="15" required></span>
+      <span><label for="pass">Mot de passe</label><input type="password" name="pass" id="pass" required></span>
+    </fieldset>
+    <?php if ($settings['same_stats_all'] == FALSE) : ?>
+    <fieldset>
+      <legend>Votre type de personnage</legend>
+      <?php if ($_SESSION['settings']['carac3_name'] != "") { ?>
+      <span>
+        <input type="radio" name="stat" value="9_9_9">équilibré
+      </span>
+      <span>
+        <input type="radio" name="stat" value="12_6_6">orienté <?php print $settings['carac1_group']; ?>
+      </span>
+      <span>
+        <input type="radio" name="stat" value="6_12_6">orienté <?php print $settings['carac2_group']; ?>
+      </span>
+      <span>
+        <input type="radio" name="stat" value="6_6_12">orienté <?php print $settings['carac3_group']; ?>
+      </span>
+      <?php
+      }
+      else {
+      ?>
+      <span>
+        <input type="radio" name="stat" value="15_5_10"><?php print 'très ' . $settings['carac1_group'] . ' mais pas ' . $settings['carac2_group']; ?>
+      </span>
+      <span>
+        <input type="radio" name="stat" value="12_8_10"><?php print 'plutôt ' . $settings['carac1_group'] . ' mais peu ' . $settings['carac2_group']; ?>
+      </span>
+      <span>
+        <input type="radio" name="stat" value="10_10_10">équilibré
+      </span>
+      <span>
+        <input type="radio" name="stat" value="8_12_10"><?php print 'peu ' . $settings['carac1_group'] . ' mais plutôt ' . $settings['carac2_group']; ?>
+      </span>
+      <span>
+        <input type="radio" name="stat" value="5_15_10"><?php print 'pas ' . $settings['carac1_group'] . ' mais très ' . $settings['carac2_group']; ?>
+      </span>
+      <?php
+      }
+      ?>
 
-  </fieldset>
-  <?php endif ?>
-  <input class="submit-button" type="submit" value="Partir à l'aventure">
-</form>
-<?php
+    </fieldset>
+    <?php endif ?>
+    <input class="submit-button" type="submit" value="Partir à l'aventure">
+  </form>
+  <?php
+}
+print "<br />";
+print "<a href='index.php'>Retour</a>";
+
 include "footer.php";
 ?>

--- a/src/newcomplete.php
+++ b/src/newcomplete.php
@@ -1,13 +1,17 @@
 <?php
 session_start();
 include "connexion.php";
+include "header.php";
 
 isset($_POST['nom']) ? $nom = $_POST['nom'] : $nom = "";
 isset($_POST['pass']) ? $pass = $_POST['pass'] : $pass = "";
 isset($_POST['stat']) ? $stat = $_POST['stat'] : $stat = "";
 $probleme = NULL;
 
-if (empty($nom) || empty($pass)) {
+if ($settings['lock_new']) {
+  $probleme = "L'aventure n'accueille pas de nouveaux personnages pour l'instant !";
+}
+elseif (empty($nom) || empty($pass)) {
   $probleme = 'Veuillez remplir le champ : ' . (empty($nom) ? 'nom' : 'mot de passe') . '.';
 }
 elseif (preg_match('/^[A-Za-z0-9-]+$/D', $nom) === 0) {
@@ -25,7 +29,7 @@ else {
     $probleme = 'Ce nom est déjà utilisé. Veuillez en choisir un autre.';
   }
 }
-include 'header.php'; ?>
+?>
 <div>
   <?php
   if (empty($probleme)) {

--- a/src/variables.php
+++ b/src/variables.php
@@ -29,6 +29,7 @@ if (
     'role_traitre' => 'traître',
     'same_stats_all' => 0,
     'random_tags' => 1,
+    'restrict_active' => 0,
     'willpower_on' => 0
   ];
   if (file_exists($tmp_path . '/settings.txt')) {

--- a/src/variables.php
+++ b/src/variables.php
@@ -30,6 +30,7 @@ if (
     'same_stats_all' => 0,
     'random_tags' => 1,
     'restrict_active' => 0,
+    'lock_new' => 0,
     'willpower_on' => 0
   ];
   if (file_exists($tmp_path . '/settings.txt')) {


### PR DESCRIPTION
Je fais une nouvelle branche pour faciliter les tests/discussions. Je resterai désormais sur celle-ci en attendant les merges (je n'y apporterai plus ou peu de modifs).

Deux fonctionnalités principales :
1/ Ajout de boutons pour retirer les rôles de Leader ou Traître.

2/ Ajout de cases à cocher permettant de limiter les tests et remises de loot aux personnages actifs (et d'un paramètre permettant de caler ça par défaut à oui ou non).