### PR TITLE
Le choix de langue fonctionne mieux sur certains serveurs

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require_once "connexion.php";
 require "variables.php";
 ?>

--- a/src/index.php
+++ b/src/index.php
@@ -2,11 +2,6 @@
 session_start();
 $page_id = 'page-index';
 include 'header.php';
-if (isset($_GET['language'])) {
-  $_SESSION['language'] = $_GET['language'];
-  setlocale(LC_ALL, $_SESSION['language']);
-  putenv("LANGUAGE=" . $_SESSION['language'] );
-}
 ?>
 <div class="index-wrapper">
   <h1>Minotaure</h1>
@@ -15,8 +10,8 @@ if (isset($_GET['language'])) {
 </div>
 <div class="secondary-links">
   <div class="languages">
-    <a href="index.php?language=en">EN</a>
-    <a href="index.php?language=fr">FR</a>
+    <a href="index.php?language=en_GB">EN</a>
+    <a href="index.php?language=fr_FR">FR</a>
   </div>
   <span><?php echo _('Une idée originale de <a href="https://twitter.com/FibreTigre" target="_blank"> FibreTigre</a>'); ?> </span>
   <span><?php echo _("Version communautaire"); ?> <a class="version" href="https://github.com/fibreville/atrpg" target="_blank"><?php print file_get_contents('./version.txt'); ?></a></span>

--- a/src/variables.php
+++ b/src/variables.php
@@ -1,12 +1,23 @@
 <?php
 // VARIABLES GENERALES.
-$lang = $_SESSION['language'] ?? 'en';
-setlocale(LC_ALL, $lang);
-putenv("LANGUAGE=" . $lang );
-bindtextdomain("minotaure", "locale");
-bind_textdomain_codeset("minotaure", "utf-8");
-textdomain("minotaure");
-
+$clean_get = filter_input_array(INPUT_GET, FILTER_SANITIZE_STRING);
+if (isset($clean_get['language'])) {
+  $lang_set = setlocale(LC_ALL, $clean_get['language']);
+  if ($lang_set === FALSE) {
+    echo _('Langue non disponible.');
+  }
+  else {
+    $_SESSION['language'] = $clean_get['language'];
+  }
+}
+if (isset($_SESSION['language'])) {
+  $lang_set = $_SESSION['language'];
+  putenv("LANGUAGE=" . $lang_set );
+  bindtextdomain("minotaure", "locale");
+  bind_textdomain_codeset("minotaure", "utf-8");
+  textdomain("minotaure");
+  $_SESSION['language'] = $lang_set;
+}
 
 $game_timestamp = file_get_contents($tmp_path . '/game_timestamp.txt');
 if ($game_timestamp == FALSE) {


### PR DESCRIPTION
Contrairement à ma machine locale, notre serveur de test n'a pas les mêmes locale disponibles.
J'ai modifié le code pour le rendre plus polyvalent.
A terme il faudra surement lister toutes les variantes (ex : en, en_GB, en_ZK, en_GB.utf8...)