### PR TITLE
Fixes to the docker setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,4 @@
 FROM php:7.2-apache
 
-RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_mysql gettext
 COPY src/ /var/www/html/
-
-CMD ["touch", "/tmp/settings.txt"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - ./src:/var/www/html
       - ./src/connexion_example.php:/var/www/html/connexion.php
+    depends_on:
+      - "serveur-mysql"
     ports:
       - "8080:80"
 

--- a/src/variables.php
+++ b/src/variables.php
@@ -35,12 +35,12 @@ if (isset($_SESSION['language'])) {
   $_SESSION['language'] = $lang_set;
 }
 
-$game_timestamp = file_get_contents($tmp_path . '/game_timestamp.txt');
+$game_timestamp = @file_get_contents($tmp_path . '/game_timestamp.txt');
 if ($game_timestamp == FALSE) {
   $game_timestamp = time();
   file_put_contents($tmp_path . '/game_timestamp.txt', $game_timestamp);
 }
-$settings_timestamp = file_get_contents($tmp_path . '/settings_timestamp.txt');
+$settings_timestamp = @file_get_contents($tmp_path . '/settings_timestamp.txt');
 if ($settings_timestamp == FALSE) {
   $settings_timestamp = time();
   file_put_contents($tmp_path . '/settings_timestamp.txt', $settings_timestamp);


### PR DESCRIPTION
Cette PR corrige deux soucis auxquels j'ai été confronté avec la configuration docker : 
- L’absence de l'extension gettext (`docker-php-ext-install gettext`)
- `CMD ["touch", "/tmp/settings.txt"]` écrase ` CMD ["apache2-foreground"]` et donc apache ne démarre pas automatiquement